### PR TITLE
Moved .forTesting() functions to new importable LambdaRuntimeTestUtils target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ),
     .target(
       name: "LambdaRuntimeTestUtils",
-      dependencies: ["AsyncHTTPClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "Logging", "Base64Kit", "LambdaRuntime"]
+      dependencies: ["LambdaRuntime"]
     ),
     .testTarget(name: "LambdaRuntimeTests", dependencies: ["LambdaRuntime", "NIOTestUtils", "Logging", "LambdaRuntimeTestUtils"])
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,11 @@ let package = Package(
       name: "LambdaRuntimeTestUtils",
       dependencies: ["NIOHTTP1", "LambdaRuntime"]
     ),
-    .testTarget(name: "LambdaRuntimeTests", dependencies: ["LambdaRuntime", "NIOTestUtils", "Logging", "LambdaRuntimeTestUtils"])
+    .testTarget(name: "LambdaRuntimeTests", dependencies: [
+        "LambdaRuntime",
+        "LambdaRuntimeTestUtils",
+        "NIOTestUtils",
+        "Logging",
+    ])
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,8 @@ let package = Package(
     ),
     .target(
       name: "LambdaRuntimeTestUtils",
-      dependencies: ["AsyncHTTPClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "Logging", "Base64Kit"]
+      dependencies: ["AsyncHTTPClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "Logging", "Base64Kit", "LambdaRuntime"]
     ),
-    .testTarget(name: "LambdaRuntimeTests", dependencies: ["LambdaRuntime", "NIOTestUtils", "Logging"])
+    .testTarget(name: "LambdaRuntimeTests", dependencies: ["LambdaRuntime", "NIOTestUtils", "Logging", "LambdaRuntimeTestUtils"])
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,10 @@ let package = Package(
       name: "LambdaRuntime",
       dependencies: ["AsyncHTTPClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "Logging", "Base64Kit"]
     ),
+    .target(
+      name: "LambdaRuntimeTestUtils",
+      dependencies: ["AsyncHTTPClient", "NIO", "NIOHTTP1", "NIOFoundationCompat", "Logging", "Base64Kit"]
+    ),
     .testTarget(name: "LambdaRuntimeTests", dependencies: ["LambdaRuntime", "NIOTestUtils", "Logging"])
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ),
     .target(
       name: "LambdaRuntimeTestUtils",
-      dependencies: ["LambdaRuntime"]
+      dependencies: ["NIOHTTP1", "LambdaRuntime"]
     ),
     .testTarget(name: "LambdaRuntimeTests", dependencies: ["LambdaRuntime", "NIOTestUtils", "Logging", "LambdaRuntimeTestUtils"])
   ]

--- a/Sources/LambdaRuntimeTestUtils/Environment+TestUtils.swift
+++ b/Sources/LambdaRuntimeTestUtils/Environment+TestUtils.swift
@@ -1,4 +1,3 @@
-import NIO
 import NIOHTTP1
 @testable import LambdaRuntime
 

--- a/Sources/LambdaRuntimeTestUtils/Environment+TestUtils.swift
+++ b/Sources/LambdaRuntimeTestUtils/Environment+TestUtils.swift
@@ -4,7 +4,7 @@ import NIOHTTP1
 
 extension Environment {
   
-  static func forTesting(
+  public static func forTesting(
     lambdaRuntimeAPI: String? = nil,
     handler         : String? = nil,
     functionName    : String? = nil,

--- a/Sources/LambdaRuntimeTestUtils/Environment+TestUtils.swift
+++ b/Sources/LambdaRuntimeTestUtils/Environment+TestUtils.swift
@@ -1,4 +1,3 @@
-import NIOHTTP1
 @testable import LambdaRuntime
 
 extension Environment {

--- a/Sources/LambdaRuntimeTestUtils/Invocation+TestUtils.swift
+++ b/Sources/LambdaRuntimeTestUtils/Invocation+TestUtils.swift
@@ -5,7 +5,7 @@ import NIOHTTP1
 
 extension Invocation {
   
-  static func forTesting(
+  public static func forTesting(
     requestId  : String       = UUID().uuidString.lowercased(),
     timeout    : TimeInterval = 1,
     functionArn: String       = "arn:aws:lambda:us-east-1:123456789012:function:custom-runtime",

--- a/Sources/LambdaRuntimeTestUtils/Invocation+TestUtils.swift
+++ b/Sources/LambdaRuntimeTestUtils/Invocation+TestUtils.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NIO
 import NIOHTTP1
 @testable import LambdaRuntime
 

--- a/Tests/LambdaRuntimeTests/ContextTests.swift
+++ b/Tests/LambdaRuntimeTests/ContextTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import XCTest
 import NIO
-import LambdaRuntimeTestUtils
 @testable import LambdaRuntime
+import LambdaRuntimeTestUtils
 
 class ContextTests: XCTestCase {
   

--- a/Tests/LambdaRuntimeTests/ContextTests.swift
+++ b/Tests/LambdaRuntimeTests/ContextTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 import NIO
+import LambdaRuntimeTestUtils
 @testable import LambdaRuntime
 
 class ContextTests: XCTestCase {

--- a/Tests/LambdaRuntimeTests/Events/APIGatewayTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/APIGatewayTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import NIO
 import NIOHTTP1
 import NIOFoundationCompat
+import LambdaRuntimeTestUtils
 @testable import LambdaRuntime
 
 class APIGatewayTests: XCTestCase {

--- a/Tests/LambdaRuntimeTests/Runtime+CodableTests.swift
+++ b/Tests/LambdaRuntimeTests/Runtime+CodableTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 import NIO
 import NIOHTTP1
+import LambdaRuntimeTestUtils
 @testable import LambdaRuntime
 
 class RuntimeCodableTests: XCTestCase {


### PR DESCRIPTION
By moving Environment.forTesting() and Invocation.forTesting() to a new build target, these functions can now be used in your own unit tests when developing Lambda functions in Swift.