### PR TITLE
Added LambdaRuntimeTestUtils Library in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,10 @@ let package = Package(
       name: "LambdaRuntime",
       targets: ["LambdaRuntime"]
     ),
+  .library(
+    name: "LambdaRuntimeTestUtils",
+    targets: ["LambdaRuntimeTestUtils"]
+  ),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.9.0")),


### PR DESCRIPTION
The LambdaRuntimeTestUtils module could not be imported from an external Lambda function SPM package without a .library() entry in Package.swift, which I have added. It now imports correctly and is usable in my Lambda function's unit tests.