### PR TITLE
Removed @_exported imports for LambdaEvents.

### DIFF
--- a/Sources/LambdaRuntime/Runtime+ALB.swift
+++ b/Sources/LambdaRuntime/Runtime+ALB.swift
@@ -1,6 +1,6 @@
 import Foundation
 import NIO
-@_exported import LambdaEvents
+import LambdaEvents
 
 extension ALB {
   

--- a/Sources/LambdaRuntime/Runtime+APIGateway.swift
+++ b/Sources/LambdaRuntime/Runtime+APIGateway.swift
@@ -1,6 +1,6 @@
 import Foundation
 import NIO
-@_exported import LambdaEvents
+import LambdaEvents
 
 extension APIGateway {
   

--- a/Tests/LambdaRuntimeTests/AWSNumberTests.swift
+++ b/Tests/LambdaRuntimeTests/AWSNumberTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 @testable import LambdaRuntime
+@testable import LambdaEvents
 
 class AWSNumberTests: XCTestCase {
   

--- a/Tests/LambdaRuntimeTests/Events/ALBTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/ALBTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 @testable import LambdaRuntime
+@testable import LambdaEvents
+
 
 class ALBTests: XCTestCase {
 

--- a/Tests/LambdaRuntimeTests/Events/APIGatewayTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/APIGatewayTests.swift
@@ -4,6 +4,7 @@ import NIO
 import NIOHTTP1
 import NIOFoundationCompat
 @testable import LambdaRuntime
+@testable import LambdaEvents
 import LambdaRuntimeTestUtils
 
 class APIGatewayTests: XCTestCase {

--- a/Tests/LambdaRuntimeTests/Events/CloudwatchTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/CloudwatchTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+@testable import LambdaEvents
 @testable import LambdaRuntime
 
 class CloudwatchTests: XCTestCase {

--- a/Tests/LambdaRuntimeTests/Events/DecodableBodyTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/DecodableBodyTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 import Base64Kit
 @testable import LambdaRuntime
+@testable import LambdaEvents
 
 class DecodableBodyTests: XCTestCase {
 

--- a/Tests/LambdaRuntimeTests/Events/DynamoDB+AttributeValueTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/DynamoDB+AttributeValueTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 import NIO
 @testable import LambdaRuntime
+@testable import LambdaEvents
 
 class DynamoDBAttributeValueTests: XCTestCase {
 

--- a/Tests/LambdaRuntimeTests/Events/DynamoDBTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/DynamoDBTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 @testable import LambdaRuntime
+@testable import LambdaEvents
 
 class DynamoDBTests: XCTestCase {
 

--- a/Tests/LambdaRuntimeTests/Events/SNSTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/SNSTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 import NIO
 @testable import LambdaRuntime
+@testable import LambdaEvents
 
 class SNSTests: XCTestCase {
 

--- a/Tests/LambdaRuntimeTests/Events/SQSTests.swift
+++ b/Tests/LambdaRuntimeTests/Events/SQSTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 import NIO
 @testable import LambdaRuntime
+@testable import LambdaEvents
 
 class SQSTests: XCTestCase {
 


### PR DESCRIPTION
This allows prevention of name clashes if import AWSSDKSwift along with LambdaRuntime.  It requires explicit imports of the LambdaEvents package when using.